### PR TITLE
Make bottom-buttons not selectable

### DIFF
--- a/doc/cla/individual/alx-khramov.md
+++ b/doc/cla/individual/alx-khramov.md
@@ -1,0 +1,11 @@
+Russian Federation, 2018-07-17
+
+I hereby agree to the terms of the Stellarium Web Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Alexander Khramov alx.khramov@gmail.com https://github.com/alx-khramov

--- a/src/components/bottom-button.vue
+++ b/src/components/bottom-button.vue
@@ -21,6 +21,7 @@
     height: 3rem;
     position: relative;
     display: inline-block;
+    user-select: none;
   }
   .bottom-button img {
     width: 100%;


### PR DESCRIPTION
Problem: a user can accidentally select bottom-buttons with mouse cursor (like text selection). It can happen when you try to move the sky near the bottom edge of the screen. It happened to me, so I decided to fix it.