### PR TITLE
Added noctuasky proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # The terms of the AGPL v3 license can be found in the main directory of this
 # repository.
 
-.PHONY: setup build dev
+.PHONY: setup build dev proxy
 
 setup: Dockerfile
 	docker build -t stellarium-web-dev .
@@ -20,3 +20,6 @@ build:
 
 start:
 	cd dist && python -m SimpleHTTPServer
+
+proxy:
+	docker run -p 8090:8090 -v "$(PWD)/proxy/nginx.conf:/etc/nginx/conf.d/default.conf" -d nginx

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -1,0 +1,8 @@
+# create a server that proxies localhost:8090 to api.noctuasky.com/api/v1
+server {
+  listen 8090;
+  location / {
+    proxy_pass https://api.noctuasky.com/api/v1/;
+    proxy_redirect https://api.noctuasky.com/ http://localhost:8090/;
+  }
+}


### PR DESCRIPTION
I've added a proxy server that permits `localhost:8090` to proxy requests to `api.noctuasky.com/api/v1`.

This allows search & item data to be displayed when `make proxy` is run parallel to the local dev application.

This should meet @PawelPleskaczynski's need in #6 as well.